### PR TITLE
[ChannelSelection] Fix crash error with some plugin...

### DIFF
--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -2039,9 +2039,12 @@ class ChannelSelection(ChannelSelectionEdit, ChannelSelectionBase, ChannelSelect
 				iPlayableService.evEnd: self.__evServiceEnd
 			})
 
-		if type(self) is ChannelSelection:
-			assert ChannelSelection.instance is None, "class InfoBar is a singleton class and just one instance of this class is allowed!"
-			ChannelSelection.instance = self
+		try:
+			if ChannelSelection.instance:
+				raise AssertionError("class InfoBar is a singleton class and just one instance of this class is allowed!")
+			except:
+				pass
+		ChannelSelection.instance = self
 		self.startServiceRef = None
 		self.history = []
 		self.history_pos = 0


### PR DESCRIPTION
<  4221.2589> 19:55:56.1865   File "/usr/lib/enigma2/python/Screens/ChannelSelection.py", line 2043, in __init__
<  4221.2611> 19:55:56.1887     assert ChannelSelection.instance is None, "class InfoBar is a singleton class and just one instance of this class is allowed!"
<  4221.2613> 19:55:56.1888 AssertionError: class InfoBar is a singleton class and just one instance of this class is allowed!
<  4221.2614> 19:55:56.1889 [ePyObject] (CallObject(<bound method ActionMap.action of <Components.ActionMap.ActionMap object at 0xb33f6658>>,('GlobalActions', 'showRaedQuickSignal')) failed)