### PR TITLE
Add GT-S2dCSS24 - Italy

### DIFF
--- a/data/unicable.xml
+++ b/data/unicable.xml
@@ -51,6 +51,7 @@ lofh: integer, alternative LOF/H value (optional, defaultvalue is 10600)
 			<product name="GT-S1dCSS24" format="jess" bootuptime="2500" scrs="0975,1025,1075,1125,1175,1225,1275,1325,1375,1425,1475,1525,1575,1625,1675,1725,1775,1825,1875,1925,1975,2025,2075,2125"/>
 			<product name="GT-S2dCSS24" format="jess" bootuptime="2500" scrs="0975,1025,1075,1125,1175,1225,1275,1325,1375,1425,1475,1525,1575,1625,1675,1725,1775,1825,1875,1925,1975,2025,2075,2125"/>
 			<product name="GT-S3DCSS24" format="jess" bootuptime="2500" scrs="0975,1025,1075,1125,1175,1225,1275,1325,1375,1425,1475,1525,1575,1625,1675,1725,1775,1825,1875,1925,1975,2025,2075,2125"/>
+			<product name="GT-S2dCSS24 - Italy" format="jess" bootuptime="2500" scrs ="1210,1420,1680,2040,985,1050,1115,1275,1340,1485 ,1550,1615,1745,1810,1875,1940"/> <!-- Programmed for 16 SCR only for the Italian market -->
 		</manufacturer>
 		<manufacturer name="Humax">
 			<product name="150 SCR" scrs="1210,1420,1680,2040"/>


### PR DESCRIPTION
Although sold as 24 SCR, it is programmed to only use 16 SCR.

![gt sat dcss 24](https://github.com/BlackHole/enigma2/assets/6644489/7f26e7c8-550b-49b5-8dd9-1d6338fcaa0c)
