### PR TITLE
dividing by zero

### DIFF
--- a/lib/python/Components/ScrollLabel.py
+++ b/lib/python/Components/ScrollLabel.py
@@ -150,7 +150,7 @@ class ScrollLabel(GUIComponent):
 
 	def updateScrollbar(self):
 		vis = max(100 * self.pageHeight // self.TotalTextHeight, 3)
-		start = (100 - vis) * self.curPos // (self.TotalTextHeight - self.pageHeight)
+		start = (100 - vis) * self.curPos // ((self.TotalTextHeight - self.pageHeight) or 1)
 		self.scrollbar.setStartEnd(start, start + vis)
 
 	def GUIcreate(self, parent):


### PR DESCRIPTION
This is a quick solution to the error when dividing by zero, in a certain situation (the difference of equal heights gives zero). 

The problem is solved in the same way in the OpenATV source code:

https://github.com/openatv/enigma2/blob/3f897f5a60903e6fc2f757fd288c8ba203aff71d/lib/python/Components/ScrollLabel.py#L225C3-L225C101

Crash report - example 1:

```
<   399.8945> 11:37:30.0423 Traceback (most recent call last):
<   399.8946> 11:37:30.0423   File "/usr/lib/enigma2/python/Plugins/Extensions/ChocholousekPicons/plugin.py", line 1774, in logWindowUpdate
<   399.9004> 11:37:30.0481     self['logWindow'].lastPage()
<   399.9007> 11:37:30.0484   File "/usr/lib/enigma2/python/Components/ScrollLabel.py", line 146, in lastPage
<   399.9012> 11:37:30.0489   File "/usr/lib/enigma2/python/Components/ScrollLabel.py", line 153, in updateScrollbar
<   399.9015> 11:37:30.0495 ZeroDivisionError: integer division or modulo by zero
<   399.9020> 11:37:30.0497 [ePyObject] (CallObject(<bound method piconsUpdateJobScreen.logWindowUpdate of <class 'Plugins.Extensions.ChocholousekPicons.plugin.piconsUpdateJobScreen'>>,()) failed)
```

Crash report - example 2:

```
<   310.2158> 14:49:01.9647 Traceback (most recent call last):
<   310.2160> 14:49:01.9649   File "/usr/lib/enigma2/python/Plugins/Extensions/ChocholousekPicons/plugin.py", line 1774, in logWindowUpdate
<   310.2266> 14:49:01.9755     self['logWindow'].lastPage()
<   310.2271> 14:49:01.9760   File "/usr/lib/enigma2/python/Components/ScrollLabel.py", line 146, in lastPage
<   310.2281> 14:49:01.9770     self.updateScrollbar()
<   310.2285> 14:49:01.9774   File "/usr/lib/enigma2/python/Components/ScrollLabel.py", line 153, in updateScrollbar
<   310.2296> 14:49:01.9785     start = (100 - vis) * self.curPos // (self.TotalTextHeight - self.pageHeight)
<   310.2310> 14:49:01.9799             ~~~~~~~~~~~~~~~~~~~~~~~~~~^^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<   310.2312> 14:49:01.9801 ZeroDivisionError: integer division or modulo by zero
<   310.2313> 14:49:01.9802 [ePyObject] (CallObject(<bound method piconsUpdateJobScreen.logWindowUpdate of <class 'Plugins.Extensions.ChocholousekPicons.plugin.piconsUpdateJobScreen'>>,()) failed)
```